### PR TITLE
Add package.json for MIP compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "urls": [
+    ["ggsheet.py", "github:PerfecXX/MicroPython-GoogleSheet/ggsheet.py"]
+  ],
+  "version": "1.0.0",
+  "deps": []
+}


### PR DESCRIPTION
This PR adds a package.json file to make the library compatible with the MicroPython Package Manager (MIP).

With this change, users can install the library using:
\\\

This will install the ggsheet.py module for Google Sheets integration.